### PR TITLE
Error incomplete while reading stamp frame

### DIFF
--- a/repository/Stamp.package/StampMedium.class/instance/readLine.st
+++ b/repository/Stamp.package/StampMedium.class/instance/readLine.st
@@ -1,27 +1,15 @@
 reading
 readLine
-	^ self
-		stringStreamContents: [ :out | 
-			| endOfLine |
-			endOfLine := false.
-			[ stream atEnd or: [ endOfLine ] ]
-				whileFalse: [ | char |
-					out position >= StampConstants maxHeaderLineLength
-						ifTrue: [ self error: 'Line too long' ].
-					"It could be that the socket stream has an empty buffer, and a connected socket without available data yet.
-			In such a state, the socket stream is not 'atEnd', and sending 'next' is expected to wait for available data. 
-			BUT, on a ConnectionClosed, it could answer nil, ignoring the exception (see #fillReadBuffer).
-			Trying to handle properly such case, by checking first if the socket stream is actually able to read a character.
-			"
-					stream peek
-						ifNil: [ 
-							stream isConnected ifFalse: [ 
-								"Signal so that sender can act accordingly"
-								ConnectionClosed signal: 'Connection close while reading StampMedium next line.'
-								 ]
-							 ]
-						ifNotNil: [ char := encoder nextFromStream: stream.
-							char = Character cr
-								ifFalse: [ char = Character lf
-										ifTrue: [ endOfLine := true ]
-										ifFalse: [ out nextPut: char ] ] ] ] ]
+	^ self stringStreamContents: [ :out | | endOfLine |
+		endOfLine := false.
+		[ stream atEnd or: [ endOfLine ] ] whileFalse: [ | char |
+			out position >= StampConstants maxHeaderLineLength
+				ifTrue: [ self error: 'Line too long' ]. 
+			(char := [ encoder nextFromStream: stream ] on: ZnIncomplete do: [ nil ])
+				ifNil: [ endOfLine := true ]
+				ifNotNil: [
+					char = Character cr
+						ifFalse: [ 
+							char = Character lf
+								ifTrue: [ endOfLine := true ]
+								ifFalse: [ out nextPut: char ] ] ] ] ]

--- a/repository/Stamp.package/StampMedium.class/instance/readLine.st
+++ b/repository/Stamp.package/StampMedium.class/instance/readLine.st
@@ -8,10 +8,18 @@ readLine
 				whileFalse: [ | char |
 					out position >= StampConstants maxHeaderLineLength
 						ifTrue: [ self error: 'Line too long' ].
-					"we first check that the socket stream is actually able to read a character.
-			It could be that the socket stream has an empty buffer, but a connected socket without available data.
-			In such a state, the socket stream will not be atEnd, but will still have nothing to read"
+					"It could be that the socket stream has an empty buffer, and a connected socket without available data yet.
+			In such a state, the socket stream is not 'atEnd', and sending 'next' is expected to wait for available data. 
+			BUT, on a ConnectionClosed, it could answer nil, ignoring the exception (see #fillReadBuffer).
+			Trying to handle properly such case, by checking first if the socket stream is actually able to read a character.
+			"
 					stream peek
+						ifNil: [ 
+							stream isConnected ifFalse: [ 
+								"Signal so that sender can act accordingly"
+								ConnectionClosed signal: 'Connection close while reading StampMedium next line.'
+								 ]
+							 ]
 						ifNotNil: [ char := encoder nextFromStream: stream.
 							char = Character cr
 								ifFalse: [ char = Character lf

--- a/repository/Stamp.package/StampMedium.class/instance/readLine.st
+++ b/repository/Stamp.package/StampMedium.class/instance/readLine.st
@@ -1,13 +1,19 @@
 reading
 readLine
-	^ self stringStreamContents: [ :out | | endOfLine |
-		endOfLine := false.
-		[ stream atEnd or: [ endOfLine ] ] whileFalse: [ | char |
-			out position >= StampConstants maxHeaderLineLength
-				ifTrue: [ self error: 'Line too long' ]. 
-			char := encoder nextFromStream: stream.
-			char = Character cr
-				ifFalse: [ 
-					char = Character lf
-						ifTrue: [ endOfLine := true ]
-						ifFalse: [ out nextPut: char ] ] ] ]
+	^ self
+		stringStreamContents: [ :out | 
+			| endOfLine |
+			endOfLine := false.
+			[ stream atEnd or: [ endOfLine ] ]
+				whileFalse: [ | char |
+					out position >= StampConstants maxHeaderLineLength
+						ifTrue: [ self error: 'Line too long' ].
+					"we first check that the socket stream is actually able to read a character.
+			It could be that the socket stream has an empty buffer, but a connected socket without available data.
+			In such a state, the socket stream will not be atEnd, but will still have nothing to read"
+					stream peek
+						ifNotNil: [ char := encoder nextFromStream: stream.
+							char = Character cr
+								ifFalse: [ char = Character lf
+										ifTrue: [ endOfLine := true ]
+										ifFalse: [ out nextPut: char ] ] ] ] ]

--- a/repository/Stamp.package/TStampFrameWithBody.trait/properties.json
+++ b/repository/Stamp.package/TStampFrameWithBody.trait/properties.json
@@ -1,5 +1,7 @@
 {
-	"name" : "TStampFrameWithBody",
 	"commentStamp" : "<historical>",
-	"category" : "Stamp-Core"
+	"classinstvars" : [ ],
+	"category" : "Stamp-Core",
+	"instvars" : [ ],
+	"name" : "TStampFrameWithBody"
 }


### PR DESCRIPTION
You were right, I should first do the pull request to the origin repo, which is this one.
Sorry, I am on my way to be used to the contribution process :)

The intention of this PR is to handle properly an unexpected state, that has been experimented: 
"the socket stream is not at end, but reading the next byte answers nil and raise errorIncomplete".

Here some more info about the case I think we faced:

"Ok I think I see a bit more precisely what can be the scenario for this "unexpected" state:
When sending "next" to the socket stream, and the buffer is empty, the expected behavior of the "next" method is to wait for data.
 As soon as it get some, it answers.
EXCEPT when the connection close:

```smalltalk
fillReadBuffer 
"Ask the socket to fill the read buffer with data. Wait for a data."
self fillReadBufferNoWait.
(readBuffer isEmpty and: [ self isConnected ])
	ifTrue: [ 
		[ self socketWaitForData ] on: ConnectionClosed do: [ ^ self ]. "when successful, recurse, else signal exception"
		self fillReadBuffer ]  
```

So if the connection close while "next" method is waiting for data, ConnectionClosed exception will be ignored , and nil will be answered. Then, patatra"